### PR TITLE
Changed _realcli to provide universal Ruby support

### DIFF
--- a/bin/conjur
+++ b/bin/conjur
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-_realcli="/usr/local/lib/ruby/gems/2.6.0/gems/conjur-cli-6.2.0/bin/conjur"
+_realcli="$(command -v conjur)"
 _rootfolder="$(pwd)"
 
 function shout {


### PR DESCRIPTION
Changed `_realcli` variable to use `command -v conjur` instead of hardcoded to allow for `rbenv` changes to versions and swapping between `rbenv global` and `rbenv local` supported.